### PR TITLE
BACKEND-905

### DIFF
--- a/src/services/content_dispatcher.ts
+++ b/src/services/content_dispatcher.ts
@@ -48,6 +48,12 @@ export class ContentDispatcher {
         navigatedUrls.push(navigatedUrl);
       }
     });
+
+    page.on("dialog", async (dialog) => {
+      this.log("got dialog (type: %s, message: %s)", dialog.type, dialog.message());
+      await dialog.dismiss();
+    });
+
     this.log("navigating to ", url);
 
     await page.goto(url);

--- a/src/services/content_dispatcher.ts
+++ b/src/services/content_dispatcher.ts
@@ -38,6 +38,23 @@ export class ContentDispatcher {
 
     this.log("created new page");
 
+    await page.setRequestInterceptionEnabled(true);
+
+    page.on("request", (interceptedRequest) => {
+      switch (interceptedRequest.resourceType) {
+        case "Image":
+        case "Media":
+        case "Font": {
+          interceptedRequest.abort();
+          break;
+        }
+        default: {
+          interceptedRequest.continue();
+          break;
+        }
+      }
+    });
+
     page.on("framenavigated", (frame: puppeteer.Frame) => {
       if (frame === mainFrame) {
         const navigatedUrl = frame.url();


### PR DESCRIPTION
## Changes

1. fixes unhandled alert/confirm dialogs could make impact to window `load`event triggering
- if alert dialog appears before receiving window load event, puppeteer just hangs, because it blocks javascript runtime
2. small performance improvements by ignoring unnecessary resource requests like image, media files (video/audio), fonts
- just confirmed this workaround reduces invocation time dramatically! (34sec to 17sec)


